### PR TITLE
Support multi-proxy configuration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,12 +56,33 @@ module.exports = function(grunt) {
             {
               host: 'www.missingcontext.com',
             }
-      ]
+      ],
+      server2: {
+        proxies: [
+          {
+            context: '/',
+            host: 'www.server2.com'
+          }
+        ]
+      },
+      server3: {
+        appendProxies: false,
+        proxies: [
+          {
+            context: '/server3',
+            host: 'www.server3.com',
+            port: 8080,
+            changeOrigin: true
+          }
+        ]
+      }
     },
 
     // Unit tests.
     nodeunit: {
-      tests: ['test/*_test.js'],
+      tests: ['test/connect_proxy_test.js'],
+      server2: 'test/server2_proxy_test.js',
+      server3: 'test/server3_proxy_test.js'
     },
 
   });
@@ -76,7 +97,23 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'configureProxies', 'nodeunit']);
+  grunt.registerTask('test', [
+    'clean', 
+    'configureProxies', 
+    'nodeunit:tests', 
+    'configureProxies:server2', 
+    'nodeunit:server2',
+    'configureProxies:server3', 
+    'nodeunit:server3',
+    ]);
+
+  // specifically test that option inheritance works for multi-level config
+  grunt.registerTask('test-inheritance', [
+    'clean', 
+    'configureProxies:server2', 
+    'nodeunit:server2',
+  ]);
+
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);

--- a/README.md
+++ b/README.md
@@ -110,10 +110,60 @@ Whether to proxy with https
 Type: `Boolean`
 Default: false
 
-Whether to change the origin on the request to the proxy, or keep the original origin. 
+Whether to change the origin on the request to the proxy, or keep the original origin.
+
+#### options.appendProxies
+Type: `Boolean`
+Default: true
+
+Set to false to isolate multi-task configuration proxy options from parent level instead of appending them.
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
+
+#### Multi-server proxy configuration
+
+grunt-contrib-connect multi-server configuration is supported. You can define _proxies_ blocks in per-server options and refer to those blocks in task invocation.
+
+```js
+grunt.initConfig({
+    connect: {
+            options: {
+                port: 9000,
+                hostname: 'localhost'
+            },
+            server2: {
+                proxies: [
+                    {
+                        context: '/cortex',
+                        host: '10.10.2.202',
+                        port: 8080,
+                        https: false,
+                        changeOrigin: false
+                    }
+                ]
+            },
+            server3: {
+                appendProxies: false,
+                proxies: [
+                    {
+                        context: '/api',
+                        host: 'example.org'
+                    }
+                ]
+            }
+        }
+})
+
+grunt.registerTask('e2etest', function (target) {
+    grunt.task.run([
+        'configureProxies:server2',
+        'open',
+        'karma'
+    ]);
+});
+```
+
 
 ## Release History
 0.1.0 Initial release

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,10 @@ utils.proxies = function() {
     return proxies;
 }
 
+utils.reset = function() {
+    proxies = [];
+}
+
 utils.proxyRequest = function (req, res, next) {
     var proxied = false;
     proxies.forEach(function(proxy) {

--- a/tasks/connect_proxy.js
+++ b/tasks/connect_proxy.js
@@ -10,12 +10,22 @@
 var utils = require('../lib/utils');
 
 module.exports = function(grunt) {
-  grunt.registerTask('configureProxies', 'Configure any specified connect proxies.', function() {
+  grunt.registerTask('configureProxies', 'Configure any specified connect proxies.', function(config) {
     // setup proxy
     var _ = grunt.util._;
     var httpProxy = require('http-proxy');
     var proxyOption;
-    var proxyOptions = grunt.config('connect.proxies') || [];
+    var proxyOptions = [];
+    utils.reset();
+    if (config) {
+        var connectOptions = grunt.config('connect.'+config) || [];
+        if (typeof connectOptions.appendProxies === 'undefined' || connectOptions.appendProxies) {
+            proxyOptions = proxyOptions.concat(grunt.config('connect.proxies') || []);
+        }
+        proxyOptions = proxyOptions.concat(connectOptions.proxies || []);
+    } else {
+        proxyOptions = proxyOptions.concat(grunt.config('connect.proxies') || []);
+    }
     proxyOptions.forEach(function(proxy) {
         proxyOption = _.defaults(proxy,  {
             port: 80,

--- a/test/server2_proxy_test.js
+++ b/test/server2_proxy_test.js
@@ -1,0 +1,24 @@
+var utils = require("../lib/utils.js");
+
+exports.server2_proxy_test = {
+  setUp: function(done) {
+    // setup here if necessary
+    done();
+  },
+  proxy_options_test: function(test) {
+    test.expect(9);
+    var proxies = utils.proxies();
+
+    test.equal(proxies.length, 3, 'should return one valid proxy');
+    test.notEqual(proxies[0].server, null, 'server should be configured');
+    test.equal(proxies[0].config.context, '/defaults', 'should have context set from config');
+    test.equal(proxies[0].config.host, 'www.defaults.com', 'should have host set from config');
+    test.equal(proxies[2].config.context, '/', 'should have context set from config');
+    test.equal(proxies[2].config.host, 'www.server2.com', 'should have host set from config');
+    test.equal(proxies[0].config.port, 80, 'should have default port 80');
+    test.equal(proxies[0].config.https, false, 'should have default http');
+    test.equal(proxies[0].config.changeOrigin, false, 'should have default change origin');
+
+    test.done();
+  }
+}

--- a/test/server3_proxy_test.js
+++ b/test/server3_proxy_test.js
@@ -1,0 +1,22 @@
+var utils = require("../lib/utils.js");
+
+exports.server3_proxy_test = {
+  setUp: function(done) {
+    // setup here if necessary
+    done();
+  },
+  proxy_options_test: function(test) {
+    test.expect(7);
+    var proxies = utils.proxies();
+
+    test.equal(proxies.length, 1, 'should have just one proxy');
+    test.notEqual(proxies[0].server, null, 'server should be configured');
+    test.equal(proxies[0].config.context, '/server3', 'should have context set from config');
+    test.equal(proxies[0].config.host, 'www.server3.com', 'should have host set from config');
+    test.equal(proxies[0].config.port, 8080, 'should have port 8080');
+    test.equal(proxies[0].config.https, false, 'should have default http');
+    test.equal(proxies[0].config.changeOrigin, true, 'should have change origin from task');
+
+    test.done();
+  }
+}


### PR DESCRIPTION
I have a particular use case that the current grunt-connect-proxy cannot satisfy: in order to run my karma functional tests, I need to proxy localhost against a deployed test instance. I'd like to do this from the same gruntfile that goes along with the main project, but grunt-connect-proxy only supports one _proxies_ -block. In development mode, I don't want to proxy the root of my server, but when running functional tests with karma, everything should be proxied to the test server.

This pull request adds support for multi-task style configuration for proxies as well.
