### PR TITLE
Updating http-proxy dependency to 0.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "http-proxy": "~0.8.7"
+    "http-proxy": "~0.10.2"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",


### PR DESCRIPTION
We had to update this dependency to avoid an issue when the host is a subdomain and you need to use the changeOrigin option. It was fixed by this pull request: https://github.com/nodejitsu/node-http-proxy/pull/231

Thanks
