### PR TITLE
Add option for rmForwardContext

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,11 @@ module.exports = function(grunt) {
               changeOrigin: true
             },
             {
+              context: '/notforwarded',
+              host: 'www.noforwardcontext.com',
+              rmForwardContext: true
+            },
+            {
               context: '/missinghost'
             },
             {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,9 @@ utils.proxyRequest = function (req, res, next) {
     var proxied = false;
     proxies.forEach(function(proxy) {
         if (!proxied && req && req.url.lastIndexOf(proxy.config.context, 0) === 0) {
+            if (proxy.config.rmForwardContext) {
+                req.url = req.url.replace(new RegExp("^" + proxy.config.context), "");
+            }
             proxy.server.proxyRequest(req, res);
             // proxying twice would cause the writing to a response header that is already sent. Bad config!
             proxied = true;

--- a/test/connect_proxy_test.js
+++ b/test/connect_proxy_test.js
@@ -32,7 +32,7 @@ exports.connect_proxy = {
     test.expect(7);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 2, 'should return two valid proxies');
+    test.equal(proxies.length, 3, 'should return three valid proxies');
     test.notEqual(proxies[0].server, null, 'server should be configured');
     test.equal(proxies[0].config.context, '/defaults', 'should have context set from config');
     test.equal(proxies[0].config.host, 'www.defaults.com', 'should have host set from config');
@@ -46,7 +46,7 @@ exports.connect_proxy = {
     test.expect(7);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 2, 'should return two valid proxies');
+    test.equal(proxies.length, 3, 'should return three valid proxies');
     test.notEqual(proxies[1].server, null, 'server should be configured');
     test.equal(proxies[1].config.context, '/full', 'should have context set from config');
     test.equal(proxies[1].config.host, 'www.full.com', 'should have host set from config');
@@ -61,7 +61,7 @@ exports.connect_proxy = {
     test.expect(5);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 2, 'should not add the 2 invalid proxies');
+    test.equal(proxies.length, 3, 'should not add the 2 invalid proxies');
     test.notEqual(proxies[0].config.context, '/missinghost', 'should not have context set from config with missing host');
     test.notEqual(proxies[0].config.host, 'www.missingcontext.com', 'should not have host set from config with missing context');
     test.notEqual(proxies[1].config.context, '/missinghost', 'should not have context set from config with missing host');

--- a/test/server2_proxy_test.js
+++ b/test/server2_proxy_test.js
@@ -9,12 +9,12 @@ exports.server2_proxy_test = {
     test.expect(9);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 3, 'should return one valid proxy');
+    test.equal(proxies.length, 4, 'should return one valid proxy');
     test.notEqual(proxies[0].server, null, 'server should be configured');
     test.equal(proxies[0].config.context, '/defaults', 'should have context set from config');
     test.equal(proxies[0].config.host, 'www.defaults.com', 'should have host set from config');
-    test.equal(proxies[2].config.context, '/', 'should have context set from config');
-    test.equal(proxies[2].config.host, 'www.server2.com', 'should have host set from config');
+    test.equal(proxies[3].config.context, '/', 'should have context set from config');
+    test.equal(proxies[3].config.host, 'www.server2.com', 'should have host set from config');
     test.equal(proxies[0].config.port, 80, 'should have default port 80');
     test.equal(proxies[0].config.https, false, 'should have default http');
     test.equal(proxies[0].config.changeOrigin, false, 'should have default change origin');


### PR DESCRIPTION
This option does not proxy the context of the url to the target server (so `localhost/context/path` gets proxied to `localhost/path`.

Not sure it really warrants a new option (this is more a problem of configuration of the target server) but here's a pull request anyway. What it be more useful to have a callback intercept for url modification? i.e.

```
{
    context: '/something',
    host: 'localhost',
    modifyUrl: function (url) {
        return url.replace("some", "every");
    }
}
```
