### PR TITLE
Set target port in proxyRequest only when needed.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,8 +81,13 @@ utils.proxyRequest = function (req, res, next) {
             // proxying twice would cause the writing to a response header that is already sent. Bad config!
             proxied = true;
 
+            var isHttpWithDefaultPort = !proxy.server.target.https && proxy.server.target.port === 80;
+            var isHttpsWithDefaultPort = proxy.server.target.https && proxy.server.target.port === 443;
+            var portString = (isHttpWithDefaultPort || isHttpsWithDefaultPort) ? '' : ':' + proxy.server.target.port;
+
             var source = req.originalUrl;
-            var target = (proxy.server.target.https ? 'https://' : 'http://') + proxy.server.target.host + ':' + proxy.server.target.port + req.url;
+            var target = (proxy.server.target.https ? 'https://' : 'http://') + proxy.server.target.host + portString + req.url;
+
             utils.log.verbose.writeln('Proxied request: ' + source + ' -> ' + target + '\n' + JSON.stringify(req.headers, true, 2));
         }
     });


### PR DESCRIPTION
I was having trouble with my proxied requests until I removed the port
from the target in proxyRequest. This commit adds the port to the target
only when something other than the default was specified for the given
protocol (80 for http, 443 for https).
