### PR TITLE
contextMatcher option, to allow complex context matching rules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,6 +84,13 @@ module.exports = function(grunt) {
               context: ['/array1','/array2'],
               host: 'www.defaults.com'
             },
+            {
+              host: 'www.defaults.com',
+              contextMatcher: function(url) {
+                var parts = url.split('/');
+                return (parts[1] === 'api' && parts[2] !== 'user');
+              }
+            }
       ],
       server2: {
         proxies: [

--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ The context(s) to match requests against. Matching requests will be proxied. Sho
 Multiple contexts can be matched for the same proxy rule via an array such as:
 context: ['/api', 'otherapi'] 
 
+#### options.contextMatcher
+Type: `Function`
+
+Instead of setting options.context, you can set a custom matcher function to allow complex rules.
+
+```js
+{
+  host: 'www.example.com',
+  contextMatcher: function(url) {
+    // should match any /api call, except /api/user
+    var parts = url.split('/');
+    return (parts[1] === 'api' && parts[2] !== 'user');
+  }
+}
+```
+
 #### options.host
 Type: `String`
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,7 +55,7 @@ utils.processRewrites = function (rewrites) {
     return rules;
 };
 
-utils.matchContext = function(context, url) {
+utils.matchContext = function(url, context) {
     var contexts = context;
     var matched = false;
     if (!_.isArray(contexts)) {
@@ -73,7 +73,7 @@ utils.proxyRequest = function (req, res, next) {
     var proxied = false;
 
     proxies.forEach(function(proxy) {
-        if (!proxied && req && utils.matchContext(proxy.config.context, req.url)) {
+        if (!proxied && req && proxy.config.contextMatcher(req.url, proxy.config.context)) {
             if (proxy.config.rules.length) {
                 proxy.config.rules.forEach(rewrite(req));
             }

--- a/tasks/connect_proxy.js
+++ b/tasks/connect_proxy.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
     var proxyOption;
     var proxyOptions = [];
     var validateProxyConfig = function(proxyOption) {
-        if (_.isUndefined(proxyOption.host) || _.isUndefined(proxyOption.context)) {
+        if (_.isUndefined(proxyOption.host) || ( _.isUndefined(proxyOption.context) && _.isUndefined(proxyOption.contextMatcher) )) {
             grunt.log.error('Proxy missing host or context configuration');
             return false;
         }
@@ -49,6 +49,7 @@ module.exports = function(grunt) {
         });
         if (validateProxyConfig(proxyOption)) {
             proxyOption.rules = utils.processRewrites(proxyOption.rewrite);
+            proxyOption.contextMatcher = proxyOption.contextMatcher || utils.matchContext;
             utils.registerProxy({
               server: new httpProxy.HttpProxy({
                 target: proxyOption,

--- a/test/connect_proxy_test.js
+++ b/test/connect_proxy_test.js
@@ -32,7 +32,7 @@ exports.connect_proxy = {
     test.expect(9);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 5, 'should return five valid proxies');
+    test.equal(proxies.length, 6, 'should return six valid proxies');
     test.notEqual(proxies[0].server, null, 'server should be configured');
     test.equal(proxies[0].config.context, '/defaults', 'should have context set from config');
     test.equal(proxies[0].config.host, 'www.defaults.com', 'should have host set from config');
@@ -48,7 +48,7 @@ exports.connect_proxy = {
     test.expect(12);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 5, 'should return five valid proxies');
+    test.equal(proxies.length, 6, 'should return six valid proxies');
     test.notEqual(proxies[1].server, null, 'server should be configured');
     test.equal(proxies[1].config.context, '/full', 'should have context set from config');
     test.equal(proxies[1].config.host, 'www.full.com', 'should have host set from config');
@@ -77,7 +77,7 @@ exports.connect_proxy = {
     test.expect(5);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 5, 'should not add the 2 invalid proxies');
+    test.equal(proxies.length, 6, 'should not add the 2 invalid proxies');
     test.notEqual(proxies[0].config.context, '/missinghost', 'should not have context set from config with missing host');
     test.notEqual(proxies[0].config.host, 'www.missingcontext.com', 'should not have host set from config with missing context');
     test.notEqual(proxies[1].config.context, '/missinghost', 'should not have context set from config with missing host');
@@ -88,9 +88,33 @@ exports.connect_proxy = {
   invalid_rewrite: function(test) {
     test.expect(3);
     var proxies = utils.proxies();
-    test.equal(proxies.length, 5, 'proxies should still be valid');
+    test.equal(proxies.length, 6, 'proxies should still be valid');
     test.equal(proxies[3].config.rules.length, 1, 'rules array should have one valid item');
     test.deepEqual(proxies[3].config.rules[0], { from: new RegExp('^/in'), to: '/thisis'}, 'rules object should be converted to regex');
+
+    test.done();
+  },
+
+  default_matcher: function(test) {
+    test.expect(4);
+    var proxies = utils.proxies();
+
+    var firstProxyConfig = proxies[0].config;
+    test.notEqual(firstProxyConfig.contextMatcher, null, 'every proxy should have a default contextMatcher');
+    test.equal(firstProxyConfig.contextMatcher( '/api/user', '/api/user' ), true, 'default matcher should match the context, when string');
+    test.equal(firstProxyConfig.contextMatcher( '/api/user', ['/api', '/other'] ), true, 'default matcher should match the context, when array');
+    test.equal(firstProxyConfig.contextMatcher( '/other/call', ['/api', '/other'] ), true, 'default matcher should match the context, when array');
+
+    test.done();
+  },
+
+  custom_matcher: function(test) {
+    test.expect(3);
+    var proxies = utils.proxies();
+
+    test.equal(proxies[5].config.contextMatcher('/api/file'), true, 'custom matcher should match any /api call, except /api/user');
+    test.equal(proxies[5].config.contextMatcher('/api/storage'), true, 'custom matcher should match any /api call, except /api/user');
+    test.equal(proxies[5].config.contextMatcher('/api/user'), false, 'custom matcher should not match /api/user');
 
     test.done();
   }

--- a/test/server2_proxy_test.js
+++ b/test/server2_proxy_test.js
@@ -9,12 +9,12 @@ exports.server2_proxy_test = {
     test.expect(10);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 6, 'should return six valid proxies');
+    test.equal(proxies.length, 7, 'should return seven valid proxies');
     test.notEqual(proxies[0].server, null, 'server should be configured');
     test.equal(proxies[0].config.context, '/defaults', 'should have context set from config');
     test.equal(proxies[0].config.host, 'www.defaults.com', 'should have host set from config');
-    test.equal(proxies[5].config.context, '/', 'should have context set from config');
-    test.equal(proxies[5].config.host, 'www.server2.com', 'should have host set from config');
+    test.equal(proxies[6].config.context, '/', 'should have context set from config');
+    test.equal(proxies[6].config.host, 'www.server2.com', 'should have host set from config');
     test.equal(proxies[0].config.port, 80, 'should have default port 80');
     test.equal(proxies[0].config.https, false, 'should have default http');
     test.equal(proxies[0].config.changeOrigin, false, 'should have default change origin');


### PR DESCRIPTION
I needed the ability to set custom context matchers, to handle url exceptions instead of exact matches. So I'm sharing my changes, if you think it will also be useful for other users :]
