### PR TITLE
Moved proxy middleware before static files in README's configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,14 @@ Add the middleware call from the connect option middleware hook
 	                    if (!Array.isArray(options.base)) {
 	                        options.base = [options.base];
 	                    }
+     
+                        // Setup the proxy
+                        middlewares.push(require('grunt-connect-proxy/lib/utils').proxyRequest);
+
 	                    options.base.forEach(function(base) {
 	                        // Serve static files.
 	                        middlewares.push(connect.static(base));
 	                    });
-	 
-	                    // Setup the proxy
-	                    middlewares.push(require('grunt-connect-proxy/lib/utils').proxyRequest);
 	 
 	                    // Make directory browse-able.
 	                    middlewares.push(connect.directory(directory));


### PR DESCRIPTION
Prioritzing static files over proxied files can lead to confusion. As an example, take this use case:
- I have a project with the following structure:

```
- api
    |- script1.php
    |- script2.php
- index.html
```
- I have a PHP server running on port 8000
- I want a connect server:
  - serving index.html and other static files
  - redirecting /api/script1.php and /api/script2.php to my PHP server

With the current configuration example, PHP files will be served by connect and not proxied to the PHP server. The current example in README can lead to confusion, as files are served anyway. I think in most cases users will want the same behavior as my example. This PR adresses this.
