### PR TITLE
Fixed issue #48

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 var utils = module.exports;
 var httpProxy = require('http-proxy');
+var grunt = require('grunt');
 var _ = require('lodash');
 var proxies = [];
 var rewrite = function (req) {
@@ -46,9 +47,9 @@ utils.processRewrites = function (rewrites) {
         if (utils.validateRewrite(rule)) {
             rule.from = new RegExp(rule.from);
             rules.push(rule);
-            utils.log.writeln('Rewrite rule created for: [' + rule.from + ' -> ' + rule.to + '].');
+            grunt.log.writeln('Rewrite rule created for: [' + rule.from + ' -> ' + rule.to + '].');
         } else {
-            utils.log.error('Invalid rule');
+            grunt.log.error('Invalid rule');
         }
     });
 
@@ -89,7 +90,7 @@ function onUpgrade(req, socket, head) {
 
             var source = req.url;
             var target = (proxy.server.target.https ? 'wss://' : 'ws://') + proxy.server.target.host + ':' + proxy.server.target.port + req.url;
-            utils.log.verbose.writeln('[WS] Proxied request: ' + source + ' -> ' + target + '\n' + JSON.stringify(req.headers, true, 2));
+            grunt.log.verbose.writeln('[WS] Proxied request: ' + source + ' -> ' + target + '\n' + JSON.stringify(req.headers, true, 2));
         }
     });
 }
@@ -98,7 +99,7 @@ function onUpgrade(req, socket, head) {
 function enableWebsocket(server) {
     if (server && !server.proxyWs) {
         server.proxyWs = true;
-        utils.log.verbose.writeln('[WS] Catching upgrade event...');
+        grunt.log.verbose.writeln('[WS] Catching upgrade event...');
         server.on('upgrade', onUpgrade);
     }
 }
@@ -125,7 +126,7 @@ utils.proxyRequest = function (req, res, next) {
 
             var source = req.originalUrl;
             var target = (proxy.server.target.https ? 'https://' : 'http://') + proxy.server.target.host + ':' + proxy.server.target.port + req.url;
-            utils.log.verbose.writeln('Proxied request: ' + source + ' -> ' + target + '\n' + JSON.stringify(req.headers, true, 2));
+            grunt.log.verbose.writeln('Proxied request: ' + source + ' -> ' + target + '\n' + JSON.stringify(req.headers, true, 2));
         }
     });
     if (!proxied) {


### PR DESCRIPTION
In certain cases, grunt isn't preloaded in time for the proxy module to correctly bind to the log instances. In order to guarantee that this is always available, I've added an explicit require() for grunt, which is then referenced for the various log statements.
