### PR TITLE
Fix Websocket support on Node 0.10

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,13 +49,10 @@ module.exports = function(grunt) {
               host: 'www.full.com',
               port: 8080,
               https: true,
-              rejectUnauthorized: true,
-              changeOrigin: true,
               xforward: true,
               rewrite: {
                 '^/full': '/anothercontext'
               },
-              timeout: 5000,
               headers: {
                 "X-Proxied-Header": "added"
               },
@@ -104,7 +101,6 @@ module.exports = function(grunt) {
             context: '/server3',
             host: 'www.server3.com',
             port: 8080,
-            changeOrigin: true
           }
         ]
       },
@@ -119,7 +115,6 @@ module.exports = function(grunt) {
             context: '/request',
             host: 'localhost',
             port: 8080,
-            changeOrigin: true,
             headers: {
               "x-proxied-header": "added"
             }

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ grunt.initConfig({
                     host: '10.10.2.202',
                     port: 8080,
                     https: false,
-                    changeOrigin: false,
                     xforward: false,
                     headers: {
                         "x-custom-added-header": value
@@ -157,18 +156,6 @@ Default: false
 
 Whether to proxy with https
 
-#### options.changeOrigin
-Type: `Boolean`
-Default: false
-
-Whether to change the origin on the request to the proxy, or keep the original origin.
-
-#### options.rejectUnauthorized:
-Type: `Boolean`
-Default: false
-
-Whether to reject self-signed certificates when https: true is set. Defaults to accept self-signed certs since proxy is meant for development environments.
-
 #### options.xforward:
 Type: `Boolean`
 Default: false
@@ -202,11 +189,6 @@ proxies: [
 ]
 ```
 
-#### options.timeout
-Type: `Number`
-
-The connection timeout in milliseconds. The default timeout is 2 minutes (120000 ms).
-
 #### options.headers
 Type: `Object`
 
@@ -239,7 +221,6 @@ grunt.initConfig({
                         host: '10.10.2.202',
                         port: 8080,
                         https: false,
-                        changeOrigin: false
                     }
                 ]
             },
@@ -276,3 +257,4 @@ grunt.registerTask('e2etest', function (target) {
 * 0.1.7 Added WebSocket support (thanks for @killfill), Headers support (thanks to @gadr), various docs fixed
 * 0.1.8 Minor websocket bug fix
 * 0.1.10 Minor bug fix
+* 0.1.11 Fix Websocket support on Node 0.10 - Bumped http-proxy dependency to 1.1.4, Removed unsupported http-proxy options (rejectUnauthorized, timeout, changeOrigin)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,12 +84,12 @@ function onUpgrade(req, socket, head) {
             if (proxy.config.rules.length) {
                 proxy.config.rules.forEach(rewrite(req));
             }
-            proxy.server.proxyWebSocketRequest(req, socket, head);
+            proxy.server.ws(req, socket, head);
 
             proxied = true;
 
             var source = req.url;
-            var target = (proxy.server.target.https ? 'wss://' : 'ws://') + proxy.server.target.host + ':' + proxy.server.target.port + req.url;
+            var target = (proxy.server.options.secure ? 'wss://' : 'ws://') + proxy.server.options.target.host + ':' + proxy.server.options.target.port + req.url;
             grunt.log.verbose.writeln('[WS] Proxied request: ' + source + ' -> ' + target + '\n' + JSON.stringify(req.headers, true, 2));
         }
     });
@@ -125,7 +125,7 @@ utils.proxyRequest = function (req, res, next) {
             proxied = true;
 
             var source = req.originalUrl;
-            var target = (proxy.server.target.https ? 'https://' : 'http://') + proxy.server.target.host + ':' + proxy.server.target.port + req.url;
+            var target = (proxy.server.options.secure ? 'https://' : 'http://') + proxy.server.options.target.host + ':' + proxy.server.options.target.port + req.url;
             grunt.log.verbose.writeln('Proxied request: ' + source + ' -> ' + target + '\n' + JSON.stringify(req.headers, true, 2));
         }
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-connect-proxy",
   "description": "Provides a http proxy as middleware for grunt connect.",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "homepage": "https://github.com/drewzboto/grunt-connect-proxy",
   "author": {
     "name": "Drewz",
@@ -22,13 +22,13 @@
   ],
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10.0"
   },
   "scripts": {
     "test": "grunt test"
   },
   "dependencies": {
-    "http-proxy": "~0.10.3",
+    "http-proxy": "~1.1.4",
     "lodash": "~0.9.0"
   },
   "devDependencies": {

--- a/tasks/connect_proxy.js
+++ b/tasks/connect_proxy.js
@@ -42,22 +42,17 @@ module.exports = function(grunt) {
         proxyOption = _.defaults(proxy,  {
             port: 80,
             https: false,
-            changeOrigin: false,
             xforward: false,
-            rejectUnauthorized: false,
             rules: [],
             ws: false
         });
         if (validateProxyConfig(proxyOption)) {
             proxyOption.rules = utils.processRewrites(proxyOption.rewrite);
             utils.registerProxy({
-              server: new httpProxy.HttpProxy({
+              server: httpProxy.createProxyServer({
                 target: proxyOption,
-                changeOrigin: proxyOption.changeOrigin,
-                enable : {
-                    xforward: proxyOption.xforward // enables X-Forwarded-For
-                },
-                timeout: proxyOption.timeout
+                secure: proxyOption.https,
+                xfwd: proxyOption.xforward
               }),
               config: proxyOption
             });

--- a/test/connect_proxy_test.js
+++ b/test/connect_proxy_test.js
@@ -29,7 +29,7 @@ exports.connect_proxy = {
     done();
   },
   default_options: function(test) {
-    test.expect(10);
+    test.expect(8);
     var proxies = utils.proxies();
 
     test.equal(proxies.length, 5, 'should return five valid proxies');
@@ -38,15 +38,13 @@ exports.connect_proxy = {
     test.equal(proxies[0].config.host, 'www.defaults.com', 'should have host set from config');
     test.equal(proxies[0].config.port, 80, 'should have default port 80');
     test.equal(proxies[0].config.https, false, 'should have default http');
-    test.equal(proxies[0].config.rejectUnauthorized, false, 'should have reject unauthorized default to false');
-    test.equal(proxies[0].config.changeOrigin, false, 'should have default change origin');
     test.equal(proxies[0].config.xforward, false, 'should have default xforward');
     test.equal(proxies[0].config.ws, false, 'should have default ws to false');
 
     test.done();
   },
   full_options: function(test) {
-    test.expect(13);
+    test.expect(11);
     var proxies = utils.proxies();
 
     test.equal(proxies.length, 5, 'should return five valid proxies');
@@ -55,8 +53,6 @@ exports.connect_proxy = {
     test.equal(proxies[1].config.host, 'www.full.com', 'should have host set from config');
     test.equal(proxies[1].config.port, 8080, 'should have port set from config');
     test.equal(proxies[1].config.https, true, 'should have http set from config');
-    test.equal(proxies[1].config.rejectUnauthorized, true, 'should have reject unauthorized set from config');
-    test.equal(proxies[1].config.changeOrigin, true, 'should have change origin set from config');
     test.equal(proxies[1].config.xforward, true, 'should have xforward set from config');
     test.equal(proxies[1].config.ws, true, 'should have ws set from config');
     test.deepEqual(proxies[1].config.rewrite, { '^/full': '/anothercontext' }, 'should have rewrite set from config');

--- a/test/server2_proxy_test.js
+++ b/test/server2_proxy_test.js
@@ -6,7 +6,7 @@ exports.server2_proxy_test = {
     done();
   },
   proxy_options_test: function(test) {
-    test.expect(11);
+    test.expect(10);
     var proxies = utils.proxies();
 
     test.equal(proxies.length, 6, 'should return six valid proxies');
@@ -17,7 +17,6 @@ exports.server2_proxy_test = {
     test.equal(proxies[5].config.host, 'www.server2.com', 'should have host set from config');
     test.equal(proxies[0].config.port, 80, 'should have default port 80');
     test.equal(proxies[0].config.https, false, 'should have default http');
-    test.equal(proxies[0].config.changeOrigin, false, 'should have default change origin');
     test.equal(proxies[0].config.ws, false, 'should have default ws to false');
     test.equal(proxies[0].config.rules.length, 0, 'rules array should have zero items');
 

--- a/test/server3_proxy_test.js
+++ b/test/server3_proxy_test.js
@@ -6,7 +6,7 @@ exports.server3_proxy_test = {
     done();
   },
   proxy_options_test: function(test) {
-    test.expect(9);
+    test.expect(8);
     var proxies = utils.proxies();
 
     test.equal(proxies.length, 1, 'should have just one proxy');
@@ -15,7 +15,6 @@ exports.server3_proxy_test = {
     test.equal(proxies[0].config.host, 'www.server3.com', 'should have host set from config');
     test.equal(proxies[0].config.port, 8080, 'should have port 8080');
     test.equal(proxies[0].config.https, false, 'should have default http');
-    test.equal(proxies[0].config.changeOrigin, true, 'should have change origin from task');
     test.equal(proxies[0].config.ws, false, 'should have ws default to false');
     test.equal(proxies[0].config.rules.length, 0, 'rules array should have zero items');
 


### PR DESCRIPTION
Addresses issue #33
- Implement http-proxy 1.1.4
- Remove unsupported http-proxy options (rejectUnauthorized, timeout, changeOrigin)
- Update tests
