### PR TITLE
Open socket client before server shutdown proxy

### DIFF
--- a/tasks/connect_proxy.js
+++ b/tasks/connect_proxy.js
@@ -53,6 +53,8 @@ module.exports = function(grunt) {
                 target: proxyOption,
                 secure: proxyOption.https,
                 xfwd: proxyOption.xforward
+              }).on('error', function (err, req, res) { 
+                grunt.log.error('Proxy error: ', err.code);
               }),
               config: proxyOption
             });


### PR DESCRIPTION
When using sockets the following case can occur:
— the server starts with the proxy (without error)
— a client open a socket through the proxy (without error)
— the server is stopped manually
— the server is started again
— the proxy fails with a `Fatal error: connect ECONNREFUSED`

This is happening because a client is still trying to connect to the server.
The proxy transfers the socket request, but the server is starting, so it does not respond to requests yet.

Handling errors on the `http-proxy` instance is enough to handle this case.
The error is displayed and further calls are properly handled.