### PR TITLE
Add the 'hideHeaders' option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -118,6 +118,12 @@ module.exports = function(grunt) {
             headers: {
               "x-proxied-header": "added"
             }
+          },
+          {
+            context: '/hideHeaders',
+            host: 'localhost',
+            port: 8081,
+            hideHeaders: ['x-hidden-header-1', 'x-hidden-header-2']
           }
         ]
       }
@@ -129,7 +135,8 @@ module.exports = function(grunt) {
       server2: 'test/server2_proxy_test.js',
       server3: 'test/server3_proxy_test.js',
       utils: 'test/utils_test.js',
-      request: 'test/request_test.js'
+      request: 'test/request_test.js',
+      hideHeaders: 'test/hide_headers_test.js'
     }
 
   });
@@ -156,7 +163,8 @@ module.exports = function(grunt) {
     'nodeunit:server3',
     'configureProxies:request',
     'connect:request',
-    'nodeunit:request'
+    'nodeunit:request',
+    'nodeunit:hideHeaders'
     ]);
 
   // specifically test that option inheritance works for multi-level config

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ grunt.initConfig({
                     xforward: false,
                     headers: {
                         "x-custom-added-header": value
-                    }
+                    },
+                    hideHeaders: ['x-removed-header']
                 }
             ]
         }
@@ -193,6 +194,11 @@ proxies: [
 Type: `Object`
 
 A map of headers to be added to proxied requests.
+
+#### options.hideHeaders
+Type: `Array`
+
+An array of headers that should be removed from the server's response.
 
 #### options.ws
 Type: `Boolean`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -104,6 +104,21 @@ function enableWebsocket(server) {
     }
 }
 
+function removeHiddenHeaders(proxy) {
+    var hiddenHeaders = proxy.config.hideHeaders;
+
+    if(hiddenHeaders && hiddenHeaders.length > 0) {
+        proxy.server.on('proxyRes', function(proxyRes) {
+            var headers = proxyRes.headers;
+            hiddenHeaders.forEach(function(header) {
+                if(header in headers) {
+                    delete headers[header];
+                }
+            });
+        });
+    }
+}
+
 utils.proxyRequest = function (req, res, next) {
     var proxied = false;
 
@@ -120,7 +135,10 @@ utils.proxyRequest = function (req, res, next) {
                     req.headers[key] = value;
                 });
             }
-            proxy.server.proxyRequest(req, res);
+
+            proxy.server.proxyRequest(req, res, proxy.server);
+            removeHiddenHeaders(proxy);
+
             // proxying twice would cause the writing to a response header that is already sent. Bad config!
             proxied = true;
 

--- a/test/hide_headers_test.js
+++ b/test/hide_headers_test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var utils = require("../lib/utils.js");
+var http = require('http');
+
+exports.connect_proxy = {
+  setUp: function(done) {
+    // setup here if necessary
+    done();
+  },
+  proxied_request: function(test) {
+    test.expect(2);
+    http.createServer(function (req, res) {
+      res.writeHead(200, {
+        'x-hidden-header-1': 'this header should be removed',
+        'x-hidden-header-2': 'this header should also be removed'
+      });
+      res.end();
+    }).listen(8081);
+
+    http.request({
+      host: 'localhost',
+      path: '/hideHeaders',
+      port: 9000
+    }, function(response) {
+      test.equal(response.headers['x-hidden-header-1'], undefined, 'hidden header should be hidden');
+      test.equal(response.headers['x-hidden-header-2'], undefined, 'hidden header should also be hidden');
+      test.done();
+    }).end();
+  }
+};


### PR DESCRIPTION
Hi,

First of all , thanks for the great work done on `grunt-connect-proxy`, it's very a helpful package!

This PR introduces the `hideHeaders` option that will simply remove the specified headers from the server's response.

It's simply done by listening to the `proxyRes` event of the used proxy, and deleting the headers from the pry server's response headers.

It has simple unit testing and some documentation, but if you have any remark I'll be glad to modify the PR.

Thanks!