### PR TITLE
Update http-proxy to the last version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "http-proxy": "~1.1.4",
+    "http-proxy": "~1.11.0",
     "lodash": "~0.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The current version has its dependencies unpinned which at the moment causes a strange error as described in issue #95.

closes #95