### PR TITLE
Fix proxy task to work with https connections.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,6 +76,19 @@ utils.matchContext = function(context, url) {
     return positiveMatch != null;
 };
 
+utils.getTargetUrl = function(options){
+    var protocol = options.ws ? 'ws' : 'http';
+    if(options.https) {
+        protocol += 's';
+    }
+
+    var target = protocol + '://' + options.host;
+    if(options.port && options.port !== 80 && options.port !== 443){
+        target += ':' + options.port;
+    }
+    return target;
+};
+
 function onUpgrade(req, socket, head) {
     var proxied = false;
 
@@ -89,7 +102,7 @@ function onUpgrade(req, socket, head) {
             proxied = true;
 
             var source = req.url;
-            var target = (proxy.server.options.secure ? 'wss://' : 'ws://') + proxy.server.options.target.host + ':' + proxy.server.options.target.port + req.url;
+            var target = utils.getTargetUrl(proxy.config) + req.url;
             grunt.log.verbose.writeln('[WS] Proxied request: ' + source + ' -> ' + target + '\n' + JSON.stringify(req.headers, true, 2));
         }
     });
@@ -143,7 +156,7 @@ utils.proxyRequest = function (req, res, next) {
             proxied = true;
 
             var source = req.originalUrl;
-            var target = (proxy.server.options.secure ? 'https://' : 'http://') + proxy.server.options.target.host + ':' + proxy.server.options.target.port + req.url;
+            var target = utils.getTargetUrl(proxy.config) + req.url;
             grunt.log.verbose.writeln('Proxied request: ' + source + ' -> ' + target + '\n' + JSON.stringify(req.headers, true, 2));
         }
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -83,7 +83,9 @@ utils.getTargetUrl = function(options){
     }
 
     var target = protocol + '://' + options.host;
-    if(options.port && options.port !== 80 && options.port !== 443){
+    var standardPort = (options.port === 80 && !options.https) || (options.port === 443 && options.https);
+
+    if(!standardPort){
         target += ':' + options.port;
     }
     return target;

--- a/tasks/connect_proxy.js
+++ b/tasks/connect_proxy.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
     }
     proxyOptions.forEach(function(proxy) {
         proxyOption = _.defaults(proxy,  {
-            port: 80,
+            port: proxy.https ? 443 : 80,
             https: false,
             xforward: false,
             rules: [],
@@ -49,14 +49,17 @@ module.exports = function(grunt) {
         if (validateProxyConfig(proxyOption)) {
             proxyOption.rules = utils.processRewrites(proxyOption.rewrite);
             utils.registerProxy({
-              server: httpProxy.createProxyServer({
-                target: proxyOption,
-                secure: proxyOption.https,
-                xfwd: proxyOption.xforward
-              }).on('error', function (err, req, res) { 
-                grunt.log.error('Proxy error: ', err.code);
-              }),
-              config: proxyOption
+                server: httpProxy.createProxyServer({
+                    target: utils.getTargetUrl(proxyOption),
+                    secure: proxyOption.https,
+                    xfwd: proxyOption.xforward,
+                    headers: {
+                        host: proxyOption.host
+                    }
+                }).on('error', function (err, req, res) {
+                    grunt.log.error('Proxy error: ', err.code);
+                }),
+                config: proxyOption
             });
             grunt.log.writeln('Proxy created for: ' +  proxyOption.context + ' to ' + proxyOption.host + ':' + proxyOption.port);
         }

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -39,5 +39,32 @@ exports.utils_test = {
     test.equal(match, true, 'should match array context with different negative context');
 
     test.done();
+  },
+
+  get_target_url_test: function(test){
+    var proxyOptions = {
+        host: 'foo.com',
+        https: true,
+        ws: false
+    };
+
+    test.expect(5);
+    test.equal(utils.getTargetUrl(proxyOptions), 'https://foo.com');
+
+    proxyOptions.https = false;
+    test.equal(utils.getTargetUrl(proxyOptions), 'http://foo.com');
+
+    proxyOptions.ws = true;
+    test.equal(utils.getTargetUrl(proxyOptions), 'ws://foo.com');
+
+    proxyOptions.https = true;
+    test.equal(utils.getTargetUrl(proxyOptions), 'wss://foo.com');
+
+    proxyOptions.port = 8080;
+    proxyOptions.ws = false;
+    proxyOptions.https = false;
+    test.equal(utils.getTargetUrl(proxyOptions), 'http://foo.com:8080');
+
+    test.done();
   }
-}
+};

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -45,25 +45,33 @@ exports.utils_test = {
     var proxyOptions = {
         host: 'foo.com',
         https: true,
+        port: 443,
         ws: false
     };
 
-    test.expect(5);
+    test.expect(6);
     test.equal(utils.getTargetUrl(proxyOptions), 'https://foo.com');
 
     proxyOptions.https = false;
+    proxyOptions.port = 80;
     test.equal(utils.getTargetUrl(proxyOptions), 'http://foo.com');
 
     proxyOptions.ws = true;
     test.equal(utils.getTargetUrl(proxyOptions), 'ws://foo.com');
 
     proxyOptions.https = true;
+    proxyOptions.port = 443
     test.equal(utils.getTargetUrl(proxyOptions), 'wss://foo.com');
 
     proxyOptions.port = 8080;
     proxyOptions.ws = false;
     proxyOptions.https = false;
     test.equal(utils.getTargetUrl(proxyOptions), 'http://foo.com:8080');
+
+    proxyOptions.port = 445;
+    proxyOptions.ws = false;
+    proxyOptions.https = true;
+    test.equal(utils.getTargetUrl(proxyOptions), 'https://foo.com:445');
 
     test.done();
   }


### PR DESCRIPTION
##### Done
Server target as string instead of options Object (http-proxy defines the target as a string [here](https://github.com/nodejitsu/node-http-proxy/blob/master/lib/http-proxy/index.js#L63))
Add a getTargetUrl utility on the utils lib to get the target url based on the proxy options.
Set the headers host explicitly on proxy creation to avoid host mismatches between local server and proxy.
Add tests for getTargetUrl utility.
