### PR TITLE
expose the secure option from http-proxy 

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ The port to proxy to.
 Type: `Boolean`
 Default: false
 
+ if the proxy should target a https end point on the destination server
+
+#### options.secure
+Type: `Boolean`
+Default: true
+
+ true/false, if you want to verify the SSL Certs (Avoids: SELF_SIGNED_CERT_IN_CHAIN errors when set to false)
+
 Whether to proxy with https
 
 #### options.xforward:

--- a/tasks/connect_proxy.js
+++ b/tasks/connect_proxy.js
@@ -42,6 +42,7 @@ module.exports = function(grunt) {
         proxyOption = _.defaults(proxy,  {
             port: proxy.https ? 443 : 80,
             https: false,
+            secure: true,
             xforward: false,
             rules: [],
             ws: false
@@ -51,7 +52,7 @@ module.exports = function(grunt) {
             utils.registerProxy({
                 server: httpProxy.createProxyServer({
                     target: utils.getTargetUrl(proxyOption),
-                    secure: proxyOption.https,
+                    secure: proxyOption.secure,
                     xfwd: proxyOption.xforward,
                     headers: {
                         host: proxyOption.host


### PR DESCRIPTION
The current wrapping of http-proxy doesn't expose the 'secure' option it assumes that https = true is the same as secure = true.
secure = true in http-proxy determines if the SSL checks should occur not the transport.  This exposes the option to users, while keeping the previous behavior the same. 