### PR TITLE
Added proxy error handling middleware support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,21 @@ Type: `Array`
 
 An array of headers that should be removed from the server's response.
 
+#### options.errorHandler
+Type: `Function`
+
+Another middleware that will be called if proxy request fails.
+Example:
+```js
+    errorHandler: function(req, res, next, err) {
+        if (err.code === 404) {
+            res.send('Some error page');
+        } else {
+            next();
+        }
+    }
+```
+
 #### options.ws
 Type: `Boolean`
 Default: false

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -151,7 +151,12 @@ utils.proxyRequest = function (req, res, next) {
                 });
             }
 
-            proxy.server.proxyRequest(req, res, proxy.server);
+            proxy.server.proxyRequest(req, res, proxy.server, function(err) {
+                if (proxy.config.errorHandler) {
+                    grunt.log.verbose.writeln('Request failed. Skipping to next midleware.');
+                    proxy.config.errorHandler(req, res, next, err);
+                }
+            });
             removeHiddenHeaders(proxy);
 
             // proxying twice would cause the writing to a response header that is already sent. Bad config!

--- a/tasks/connect_proxy.js
+++ b/tasks/connect_proxy.js
@@ -45,6 +45,7 @@ module.exports = function(grunt) {
             secure: true,
             xforward: false,
             rules: [],
+            errorHandler: function(req, res, next) {  },
             ws: false
         });
         if (validateProxyConfig(proxyOption)) {


### PR DESCRIPTION
It would be nice to handle proxy errors (show nice page on 404, or pass call to another middleware if proxy fails).

In  my case I want to set up connect server, that will route request between `frontend grunt` serve and backend `grunt serve`.

Then I can just set up: 
1) proxy to frontend, 
2) if 404, than it's not a frontend file and backend proxy should handle the request.