### PR TITLE
Fix typo in options.context section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Type: `String` or `Array`
 
 The context(s) to match requests against. Matching requests will be proxied. Should start with /. Should not end with /
 Multiple contexts can be matched for the same proxy rule via an array such as:
-context: ['/api', 'otherapi']
+context: ['/api', '/otherapi']
 
 #### options.host
 Type: `String`


### PR DESCRIPTION
Small typo, missing ```/``` in the options.context section