### PR TITLE
Add function support to context rewrites

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,6 +84,15 @@ module.exports = function(grunt) {
             {
               context: ['/array1','/array2'],
               host: 'www.defaults.com'
+            },
+            {
+              context: '/rewrite',
+              host: 'www.yetanothercontext.com',
+              rewrite: {
+                '^(/)rewrite': function(match, p1) {
+                  return p1;
+                }
+              }
             }
       ],
       server2: {

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Set to false to isolate multi-task configuration proxy options from parent level
 #### options.rewrite
 Type: `Object`
 
-Allows rewrites of url (including context) when proxying. The object's keys serve as the regex used in the replacement operation. As an example the following proxy configuration will remove the context when proxying:
+Allows rewrites of url (including context) when proxying. The object's keys serve as the regex used in the replacement operation. As an example the following proxy configuration will update the context when proxying:
 
 ```js
 proxies: [
@@ -189,7 +189,10 @@ proxies: [
     port: 8080,
     rewrite: {
         '^/removingcontext': '',
-        '^/changingcontext': '/anothercontext'
+        '^/changingcontext': '/anothercontext',
+        '^/updating(context)': function(match, p1) {
+            return '/new' + p1;
+        }
     }
 ]
 ```

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,7 +29,7 @@ utils.validateRewrite = function (rule) {
         typeof rule.from === 'undefined' ||
         typeof rule.to === 'undefined' ||
         typeof rule.from !== 'string' ||
-        typeof rule.to !== 'string') {
+        (typeof rule.to !== 'string' && typeof rule.to !== 'function')) {
         return false;
     }
     return true;

--- a/test/connect_proxy_test.js
+++ b/test/connect_proxy_test.js
@@ -32,7 +32,7 @@ exports.connect_proxy = {
     test.expect(8);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 5, 'should return five valid proxies');
+    test.equal(proxies.length, 6, 'should return six valid proxies');
     test.notEqual(proxies[0].server, null, 'server should be configured');
     test.equal(proxies[0].config.context, '/defaults', 'should have context set from config');
     test.equal(proxies[0].config.host, 'www.defaults.com', 'should have host set from config');
@@ -47,7 +47,7 @@ exports.connect_proxy = {
     test.expect(11);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 5, 'should return five valid proxies');
+    test.equal(proxies.length, 6, 'should return five valid proxies');
     test.notEqual(proxies[1].server, null, 'server should be configured');
     test.equal(proxies[1].config.context, '/full', 'should have context set from config');
     test.equal(proxies[1].config.host, 'www.full.com', 'should have host set from config');
@@ -75,7 +75,7 @@ exports.connect_proxy = {
     test.expect(5);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 5, 'should not add the 2 invalid proxies');
+    test.equal(proxies.length, 6, 'should not add the 2 invalid proxies');
     test.notEqual(proxies[0].config.context, '/missinghost', 'should not have context set from config with missing host');
     test.notEqual(proxies[0].config.host, 'www.missingcontext.com', 'should not have host set from config with missing context');
     test.notEqual(proxies[1].config.context, '/missinghost', 'should not have context set from config with missing host');
@@ -86,10 +86,19 @@ exports.connect_proxy = {
   invalid_rewrite: function(test) {
     test.expect(3);
     var proxies = utils.proxies();
-    test.equal(proxies.length, 5, 'proxies should still be valid');
+    test.equal(proxies.length, 6, 'proxies should still be valid');
     test.equal(proxies[3].config.rules.length, 1, 'rules array should have one valid item');
     test.deepEqual(proxies[3].config.rules[0], { from: new RegExp('^/in'), to: '/thisis'}, 'rules object should be converted to regex');
 
     test.done();
-  }
+  },
+
+  function_rewrite: function(test) {
+    test.expect(1);
+    console.log(utils.proxies());
+    var proxies = utils.proxies(),
+        rules = proxies[5].config.rules[0];
+    test.equal('/rewrite'.replace(rules.from, rules.to), '/', 'should execute function when replacing');
+    test.done();
+  },
 };

--- a/test/server2_proxy_test.js
+++ b/test/server2_proxy_test.js
@@ -9,12 +9,12 @@ exports.server2_proxy_test = {
     test.expect(10);
     var proxies = utils.proxies();
 
-    test.equal(proxies.length, 6, 'should return six valid proxies');
+    test.equal(proxies.length, 7, 'should return seven valid proxies');
     test.notEqual(proxies[0].server, null, 'server should be configured');
     test.equal(proxies[0].config.context, '/defaults', 'should have context set from config');
     test.equal(proxies[0].config.host, 'www.defaults.com', 'should have host set from config');
-    test.equal(proxies[5].config.context, '/', 'should have context set from config');
-    test.equal(proxies[5].config.host, 'www.server2.com', 'should have host set from config');
+    test.equal(proxies[6].config.context, '/', 'should have context set from config');
+    test.equal(proxies[6].config.host, 'www.server2.com', 'should have host set from config');
     test.equal(proxies[0].config.port, 80, 'should have default port 80');
     test.equal(proxies[0].config.https, false, 'should have default http');
     test.equal(proxies[0].config.ws, false, 'should have default ws to false');


### PR DESCRIPTION
Hi there,

This PR adds support for (possibly?) smarter context rewrites. It allows use of functions when performing `String.prototype.replace()` calls (see [reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter)). A use case to explain why I've needed this recently:

```js
{
  host: 'www.example.com',
  context: '/books',
  rewrite: {
    'page=(\\d+)': function(match, p1) {
      var per_page = 10;
      return '_offset=' + (per_page * p1);
    }
  }
}
```

This allowed me to easily transform `/books?page=1` into `/books?_offset=10`.