### PR TITLE
Hiding headers should be case insensitive

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -123,7 +123,7 @@ module.exports = function(grunt) {
             context: '/hideHeaders',
             host: 'localhost',
             port: 8081,
-            hideHeaders: ['x-hidden-header-1', 'x-hidden-header-2']
+            hideHeaders: ['x-hidden-header-1', 'X-HiDdEn-HeAdEr-2']
           }
         ]
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -123,6 +123,10 @@ function removeHiddenHeaders(proxy) {
     var hiddenHeaders = proxy.config.hideHeaders;
 
     if(hiddenHeaders && hiddenHeaders.length > 0) {
+        hiddenHeaders = hiddenHeaders.map(function(header) {
+          return header.toLowerCase();
+        });
+
         proxy.server.on('proxyRes', function(proxyRes) {
             var headers = proxyRes.headers;
             hiddenHeaders.forEach(function(header) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt-contrib-nodeunit": "~0.4.1",
     "grunt": "~0.4.1",
     "grunt-contrib-connect": "~0.5.0"
   },

--- a/test/hide_headers_test.js
+++ b/test/hide_headers_test.js
@@ -23,8 +23,9 @@ exports.connect_proxy = {
       path: '/hideHeaders',
       port: 9000
     }, function(response) {
+
       test.equal(response.headers['x-hidden-header-1'], undefined, 'hidden header should be hidden');
-      test.equal(response.headers['x-hidden-header-2'], undefined, 'hidden header should also be hidden');
+      test.equal(response.headers['x-hidden-header-2'], undefined, 'header hiding is case insensitive');
       test.done();
     }).end();
   }


### PR DESCRIPTION
As shown in the test modification, if the user was writing headers with upper-case characters, the headers were not removed from the request. This pull request makes the header-hiding behaviour less confusing by lower-casing the user input before filtering the lower-case headers coming from the network.

I also updated the node-unit version to make it run on newer node versions.