### PR TITLE
Keep proxies list for multiple connect servers

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -135,6 +135,27 @@ module.exports = function(grunt) {
             hideHeaders: ['x-hidden-header-1', 'X-HiDdEn-HeAdEr-2']
           }
         ]
+      },
+      testServer1: {
+        appendProxies: false,
+        proxies: [
+          {
+            context: '/testServer1',
+            host: 'localhost',
+            port: 8080,
+          }
+        ]
+      },
+      testServer2: {
+        appendProxies: false,
+        keepProxiesOnConnect: true,
+        proxies: [
+          {
+            context: '/',
+            host: 'localhost',
+            port: 8081,
+          }
+        ]
       }
     },
 
@@ -145,7 +166,8 @@ module.exports = function(grunt) {
       server3: 'test/server3_proxy_test.js',
       utils: 'test/utils_test.js',
       request: 'test/request_test.js',
-      hideHeaders: 'test/hide_headers_test.js'
+      hideHeaders: 'test/hide_headers_test.js',
+      keepProxiesOnConnect: 'test/keep_proxies_on_connect.js'
     }
 
   });
@@ -173,8 +195,15 @@ module.exports = function(grunt) {
     'configureProxies:request',
     'connect:request',
     'nodeunit:request',
-    'nodeunit:hideHeaders'
-    ]);
+    'nodeunit:hideHeaders',
+    'test-keepProxiesOnConnect'
+  ]);
+
+  grunt.registerTask('test-keepProxiesOnConnect', [
+    'configureProxies:testServer1',
+    'configureProxies:testServer2',
+    'nodeunit:keepProxiesOnConnect'
+  ]);
 
   // specifically test that option inheritance works for multi-level config
   grunt.registerTask('test-inheritance', [

--- a/README.md
+++ b/README.md
@@ -147,6 +147,24 @@ Default: 80
 
 The port to proxy to.
 
+#### options.matchContext
+Type: `Function`
+Default: null
+
+Allows to specify a specific matchContext used by the proxy instance to check if the context is
+valid. It receives the request object as a parameter.
+
+``` javascript
+proxies: [{
+    context: '/',
+    host: 'www.foo.com',
+    port: 8080,
+    matchContext: function(req){
+        return req.headers.host === 'localhost'
+    }
+}];
+```
+
 #### options.https
 Type: `Boolean`
 Default: false
@@ -176,6 +194,12 @@ Type: `Boolean`
 Default: true
 
 Set to false to isolate multi-task configuration proxy options from parent level instead of appending them.
+
+#### options.keepProxiesOnConnect
+Type: `Boolean`
+Default: false
+
+Allows to keep the proxies list with the proxies configured on previous connect tasks.
 
 #### options.rewrite
 Type: `Object`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,6 +76,16 @@ utils.matchContext = function(context, url) {
     return positiveMatch != null;
 };
 
+utils.matchContextAndProxyContext = function(proxy, req){
+    var positiveMatch = req && utils.matchContext(proxy.config.context, req.url);
+
+    if(typeof proxy.config.matchContext === 'function'){
+        positiveMatch = positiveMatch && proxy.config.matchContext(req);
+    }
+
+    return positiveMatch;
+};
+
 utils.getTargetUrl = function(options){
     var protocol = options.ws ? 'ws' : 'http';
     if(options.https) {
@@ -95,7 +105,7 @@ function onUpgrade(req, socket, head) {
     var proxied = false;
 
     proxies.forEach(function(proxy) {
-        if (!proxied && req && proxy.config.ws && utils.matchContext(proxy.config.context, req.url)) {
+        if (!proxied && proxy.config.ws && utils.matchContextAndProxyContext(proxy, req)) {
             if (proxy.config.rules.length) {
                 proxy.config.rules.forEach(rewrite(req));
             }
@@ -144,7 +154,7 @@ utils.proxyRequest = function (req, res, next) {
     enableWebsocket(req.connection.server);
 
     proxies.forEach(function(proxy) {
-        if (!proxied && req && utils.matchContext(proxy.config.context, req.url)) {
+        if (!proxied && utils.matchContextAndProxyContext(proxy, req)) {
             if (proxy.config.rules.length) {
                 proxy.config.rules.forEach(rewrite(req));
             }

--- a/tasks/connect_proxy.js
+++ b/tasks/connect_proxy.js
@@ -15,6 +15,7 @@ module.exports = function(grunt) {
     // setup proxy
     var httpProxy = require('http-proxy');
     var proxyOption;
+    var connectOptions;
     var proxyOptions = [];
     var validateProxyConfig = function(proxyOption) {
         if (_.isUndefined(proxyOption.host) || _.isUndefined(proxyOption.context)) {
@@ -27,10 +28,9 @@ module.exports = function(grunt) {
         return true;
     };
 
-    utils.reset();
     utils.log = grunt.log;
     if (config) {
-        var connectOptions = grunt.config('connect.'+config) || [];
+        connectOptions = grunt.config('connect.'+config) || [];
         if (typeof connectOptions.appendProxies === 'undefined' || connectOptions.appendProxies) {
             proxyOptions = proxyOptions.concat(grunt.config('connect.proxies') || []);
         }
@@ -38,6 +38,11 @@ module.exports = function(grunt) {
     } else {
         proxyOptions = proxyOptions.concat(grunt.config('connect.proxies') || []);
     }
+
+    if(!connectOptions || !connectOptions.keepProxiesOnConnect){
+        utils.reset();
+    }
+
     proxyOptions.forEach(function(proxy) {
         proxyOption = _.defaults(proxy,  {
             port: proxy.https ? 443 : 80,
@@ -46,7 +51,8 @@ module.exports = function(grunt) {
             xforward: false,
             rules: [],
             errorHandler: function(req, res, next) {  },
-            ws: false
+            ws: false,
+            matchContext: null
         });
         if (validateProxyConfig(proxyOption)) {
             proxyOption.rules = utils.processRewrites(proxyOption.rewrite);

--- a/test/keep_proxies_on_connect.js
+++ b/test/keep_proxies_on_connect.js
@@ -1,0 +1,40 @@
+var utils = require("../lib/utils.js");
+
+exports.keep_proxies_on_connect = {
+  setUp: function(done) {
+    // setup here if necessary
+    done();
+  },
+
+  proxy_options_test: function(test) {
+    test.expect(11);
+
+    var proxies = utils.proxies();
+
+    test.equal(proxies.length, 2, 'should return two valid proxies');
+
+    var checkProxyConfig = function(proxy, config){
+      Object.keys(config).forEach(function(property){
+        test.equal(proxy[property], config[property], 'should have ' + property + ' set from config');
+      });
+    };
+
+    checkProxyConfig(proxies[0].config, {
+      context: '/testServer1',
+      host: 'localhost',
+      port: 8080,
+      https: false,
+      ws: false
+    });
+
+    checkProxyConfig(proxies[1].config, {
+      context: '/',
+      host: 'localhost',
+      port: 8081,
+      https: false,
+      ws: false
+    });
+
+    test.done();
+  }
+}

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -41,6 +41,50 @@ exports.utils_test = {
     test.done();
   },
 
+  match_context_and_proxy_context_test: function(test){
+    var proxy = {
+        config: {
+            host: 'foo.com',
+            https: true,
+            port: 443,
+            ws: false
+        }
+    };
+    var req = {
+        url: '/foo/bar',
+        headers: {
+            host: 'bar.com'
+        }
+    };
+
+    var match;
+
+    test.expect(5);
+
+    proxy.config.context = '/';
+    match = utils.matchContextAndProxyContext(proxy, req);
+    test.equal(match, true, 'should match default match with no proxy match context set');
+
+    proxy.config.context = '/foo/';
+    match = utils.matchContextAndProxyContext(proxy, req);
+    test.equal(match, true, 'should match default match with no proxy match context set');
+
+    proxy.config.matchContext = function(req){
+        return false;
+    };
+    match = utils.matchContextAndProxyContext(proxy, req);
+    test.equal(match, false, 'should not match as the proxy match context is false');
+
+    proxy.config.matchContext = function(contextReq){
+        test.deepEqual(req, contextReq, 'the context match req should be equal to the one above');
+        return true;
+    };
+    match = utils.matchContextAndProxyContext(proxy, req);
+    test.equal(match, true, 'should match as the proxy match context is true');
+
+    test.done();
+  },
+
   get_target_url_test: function(test){
     var proxyOptions = {
         host: 'foo.com',

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -59,7 +59,7 @@ exports.utils_test = {
 
     var match;
 
-    test.expect(5);
+    test.expect(6);
 
     proxy.config.context = '/';
     match = utils.matchContextAndProxyContext(proxy, req);
@@ -81,6 +81,10 @@ exports.utils_test = {
     };
     match = utils.matchContextAndProxyContext(proxy, req);
     test.equal(match, true, 'should match as the proxy match context is true');
+
+    proxy.config.context = '/bar/';
+    match = utils.matchContextAndProxyContext(proxy, req);
+    test.equal(match, false, 'should not match as context not match');
 
     test.done();
   },


### PR DESCRIPTION
- Add a `keepProxiesOnConnect` option to setup connect.
- Add a proxy config `matchContext` function to verify
  context applygin proxy based rules.
- Add tests for `keepProxiesOnConnect` flag.
- Add tests for proxy `matchContext` function.
