### PR TITLE
Add headers from proxy config to WebSocket requests

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -91,6 +91,15 @@ utils.getTargetUrl = function(options){
     return target;
 };
 
+// Add headers present in the config object
+utils.addHeaders = function(config, req){
+    if (config.headers != null) {
+        _.forOwn(config.headers, function(value, key) {
+            req.headers[key] = value;
+        });
+    }
+};
+
 function onUpgrade(req, socket, head) {
     var proxied = false;
 
@@ -99,6 +108,9 @@ function onUpgrade(req, socket, head) {
             if (proxy.config.rules.length) {
                 proxy.config.rules.forEach(rewrite(req));
             }
+            
+            utils.addHeaders(proxy.config, req);
+            
             proxy.server.ws(req, socket, head);
 
             proxied = true;
@@ -148,12 +160,8 @@ utils.proxyRequest = function (req, res, next) {
             if (proxy.config.rules.length) {
                 proxy.config.rules.forEach(rewrite(req));
             }
-            // Add headers present in the config object
-            if (proxy.config.headers != null) {
-                _.forOwn(proxy.config.headers, function(value, key) {
-                    req.headers[key] = value;
-                });
-            }
+            
+            utils.addHeaders(proxy.config, req);
 
             proxy.server.proxyRequest(req, res, proxy.server, function(err) {
                 if (proxy.config.errorHandler) {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -60,7 +60,7 @@ exports.utils_test = {
     test.equal(utils.getTargetUrl(proxyOptions), 'ws://foo.com');
 
     proxyOptions.https = true;
-    proxyOptions.port = 443
+    proxyOptions.port = 443;
     test.equal(utils.getTargetUrl(proxyOptions), 'wss://foo.com');
 
     proxyOptions.port = 8080;
@@ -73,6 +73,26 @@ exports.utils_test = {
     proxyOptions.https = true;
     test.equal(utils.getTargetUrl(proxyOptions), 'https://foo.com:445');
 
+    test.done();
+  },
+  
+  add_headers_test: function(test){
+    var testConfig = {
+        headers: {
+            header1: 'foo',
+            header2: 'bar'
+        }
+    };
+    var testReq = {
+        headers: { }
+    };
+    
+    test.expect(2);
+    
+    utils.addHeaders(testConfig, testReq);
+    test.equal(testReq.headers.header1, 'foo');
+    test.equal(testReq.headers.header2, 'bar');
+    
     test.done();
   }
 };


### PR DESCRIPTION
For my project I have to add an additional header (authorization) to proxied WebSocket requests and noticed that it didn't seem to be supported yet. Usage:

```
{
    context: '/foobar',
    host: 'host',
    port: 1234,
    headers: {
        Authorization: 'foobar'
    },
    ws: true
}
```
