### PR TITLE
WS : Add headers present in the config object

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -99,6 +99,12 @@ function onUpgrade(req, socket, head) {
             if (proxy.config.rules.length) {
                 proxy.config.rules.forEach(rewrite(req));
             }
+             // Add headers present in the config object
+            if (proxy.config.headers != null) {
+                _.forOwn(proxy.config.headers, function (value, key) {
+                    req.headers[key] = value;
+                });
+            }
             proxy.server.ws(req, socket, head);
 
             proxied = true;


### PR DESCRIPTION
After hours of fight, we finaly found that the header from config file where not set for proxied WS (as it is on http/s)... with this small fix, it works like a charm